### PR TITLE
fix: create the same provider once

### DIFF
--- a/lib/cluster/common/cluster.decorator.spec.ts
+++ b/lib/cluster/common/cluster.decorator.spec.ts
@@ -46,7 +46,7 @@ describe('InjectCluster', () => {
     });
 
     test('should have 4 members in array namespaces', () => {
-        expect(namespaces).toHaveLength(4);
+        expect(namespaces).toHaveLength(3);
         expect(namespaces).toContain(name.provide);
         expect(namespaces).toContain(gender.provide);
         expect(namespaces).toContain(age.provide);

--- a/lib/cluster/common/cluster.decorator.ts
+++ b/lib/cluster/common/cluster.decorator.ts
@@ -5,7 +5,7 @@ import { DEFAULT_CLUSTER_NAMESPACE } from '../cluster.constants';
 export const namespaces: ClientNamespace[] = [];
 
 export const InjectCluster = (namespace: ClientNamespace = DEFAULT_CLUSTER_NAMESPACE): ReturnType<typeof Inject> => {
-    namespaces.push(namespace);
+    if (!namespaces.includes(namespace)) namespaces.push(namespace);
 
     return Inject(namespace);
 };

--- a/lib/redis/common/redis.decorator.spec.ts
+++ b/lib/redis/common/redis.decorator.spec.ts
@@ -46,7 +46,7 @@ describe('InjectRedis', () => {
     });
 
     test('should have 4 members in array namespaces', () => {
-        expect(namespaces).toHaveLength(4);
+        expect(namespaces).toHaveLength(3);
         expect(namespaces).toContain(name.provide);
         expect(namespaces).toContain(gender.provide);
         expect(namespaces).toContain(age.provide);

--- a/lib/redis/common/redis.decorator.ts
+++ b/lib/redis/common/redis.decorator.ts
@@ -5,7 +5,7 @@ import { DEFAULT_REDIS_NAMESPACE } from '../redis.constants';
 export const namespaces: ClientNamespace[] = [];
 
 export const InjectRedis = (namespace: ClientNamespace = DEFAULT_REDIS_NAMESPACE): ReturnType<typeof Inject> => {
-    namespaces.push(namespace);
+    if (!namespaces.includes(namespace)) namespaces.push(namespace);
 
     return Inject(namespace);
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

If a consumer injects the same client multiple, the module will create the same provider multiple times. This will cause performance problems.

## What is the new behavior?

- prevent the same provider be created multiple

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Aug 27, 2021, 22:46 UTC+8
