### PR TITLE
update nestjs peer dependencies to v10

### DIFF
--- a/packages/redis-health/package.json
+++ b/packages/redis-health/package.json
@@ -47,9 +47,9 @@
     "@liaoliaots/nestjs-redis": "workspace:*"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0",
-    "@nestjs/terminus": "^9.0.0",
+    "@nestjs/common": "^10.0.0 || ^9.0.0",
+    "@nestjs/core": "^10.0.0 || ^9.0.0",
+    "@nestjs/terminus": "^10.0.0 || ^9.0.0",
     "ioredis": "^5.0.0"
   },
   "engines": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -41,8 +41,8 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0",
+    "@nestjs/common": "^10.0.0 || ^9.0.0",
+    "@nestjs/core": "^10.0.0 || ^9.0.0",
     "ioredis": "^5.0.0"
   },
   "engines": {


### PR DESCRIPTION
## PR Type

Update peer dependencies of `@nestjs` to the latest version (v10).

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

NestJS recently released version 10 approximately two weeks ago, resulting in our project encountering the following warning:

```
─┬ @liaoliaots/nestjs-redis 9.0.5
│ ├── ✕ unmet peer @nestjs/common@^9.0.0: found 10.0.4
│ └── ✕ unmet peer @nestjs/core@^9.0.0: found 10.0.4
```

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
