### PR TITLE
fix: application shutdown

### DIFF
--- a/packages/redis/lib/cluster/cluster.module.ts
+++ b/packages/redis/lib/cluster/cluster.module.ts
@@ -72,9 +72,9 @@ export class ClusterModule implements OnApplicationShutdown {
   }
 
   async onApplicationShutdown(): Promise<void> {
-    const { closeClient } = this.moduleRef.get<ClusterModuleOptions>(CLUSTER_MERGED_OPTIONS);
+    const { closeClient } = this.moduleRef.get<ClusterModuleOptions>(CLUSTER_MERGED_OPTIONS, { strict: false });
     if (closeClient) {
-      const results = await destroy(this.moduleRef.get<ClusterClients>(CLUSTER_CLIENTS));
+      const results = await destroy(this.moduleRef.get<ClusterClients>(CLUSTER_CLIENTS, {strict : false }));
       results.forEach(([namespace, quit]) => {
         if (isResolution(namespace) && isRejection(quit) && isError(quit.reason)) {
           logger.error(ERROR_LOG(parseNamespace(namespace.value), quit.reason.message), quit.reason.stack);

--- a/packages/redis/lib/redis/redis.module.ts
+++ b/packages/redis/lib/redis/redis.module.ts
@@ -72,9 +72,9 @@ export class RedisModule implements OnApplicationShutdown {
   }
 
   async onApplicationShutdown(): Promise<void> {
-    const { closeClient } = this.moduleRef.get<RedisModuleOptions>(REDIS_MERGED_OPTIONS);
+    const { closeClient } = this.moduleRef.get<RedisModuleOptions>(REDIS_MERGED_OPTIONS, { strict: false });
     if (closeClient) {
-      const results = await destroy(this.moduleRef.get<RedisClients>(REDIS_CLIENTS));
+      const results = await destroy(this.moduleRef.get<RedisClients>(REDIS_CLIENTS, { strict: false }));
       results.forEach(([namespace, quit]) => {
         if (isResolution(namespace) && isRejection(quit) && isError(quit.reason)) {
           logger.error(ERROR_LOG(parseNamespace(namespace.value), quit.reason.message), quit.reason.stack);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently when my app has `enableShutdownHooks` it will fail every time because of:
```
.../node_modules/@nestjs/core/injector/instance-links-host.js:24
            throw new unknown_element_exception_1.UnknownElementException(this.getInstanceNameByToken(token));
                  ^

Error: Nest could not find Symbol() element (this provider does not exist in the current context)
    at InstanceLinksHost.get (.../node_modules/@nestjs/core/injector/instance-links-host.js:24:19)
    at Object.find (.../node_modules/@nestjs/core/injector/abstract-instance-resolver.js:8:60)
    at Object.get (.../node_modules/@nestjs/core/injector/module.js:399:29)
    at RedisModule2.onApplicationShutdown (.../node_modules/@liaoliaots/nestjs-redis/dist/redis/redis.module.js:68:48)
    at callAppShutdownHook (.../node_modules/@nestjs/core/hooks/on-app-shutdown.hook.js:51:35)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at NestApplication.callShutdownHook (.../node_modules/@nestjs/core/nest-application-context.js:254:13)
    at process.cleanup (.../node_modules/@nestjs/core/nest-application-context.js:191:17)
```

Digging through the NestJS source code and logging all the issues, this:
https://github.com/nestjs/nest/blob/master/packages/core/injector/module.ts#L611-L615
the `self.id` NEVER matches up with the ID of whatever 
`this.moduleRef.get<RedisModuleOptions>(REDIS_MERGED_OPTIONS)`
or `this.moduleRef.get<RedisClients>(REDIS_CLIENTS)` is.

This check always fails:
https://github.com/nestjs/nest/blob/master/packages/core/injector/instance-links-host.ts#L44-L46

This PR also address and fixes this issue:
https://github.com/liaoliaots/nestjs-redis/issues/335

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
